### PR TITLE
Adding config for Auto update support

### DIFF
--- a/OnbordingTemplates/ExistingVmOnboarding/ExistingVmOnboardingTemplate.json
+++ b/OnbordingTemplates/ExistingVmOnboarding/ExistingVmOnboardingTemplate.json
@@ -45,7 +45,7 @@
             "resources": [
                 {
                     "type": "extensions",
-                    "apiVersion": "2018-10-01",
+                    "apiVersion": "2019-12-01",
                     "name": "[variables('DaExtensionName')]",
                     "location": "[parameters('VmLocation')]",
                     "dependsOn": [
@@ -55,7 +55,9 @@
                         "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
                         "type": "[variables('DaExtensionType')]",
                         "typeHandlerVersion": "[variables('DaExtensionVersion')]",
-                        "autoUpgradeMinorVersion": true
+                        "autoUpgradeMinorVersion": true,
+                        "enableAutomaticUpgrade": true,
+                        "settings": {}
                     }
                 },
                 {

--- a/OnbordingTemplates/ExistingVmssOnboarding/ExistingVmssOnboardingTemplate.json
+++ b/OnbordingTemplates/ExistingVmssOnboarding/ExistingVmssOnboardingTemplate.json
@@ -45,7 +45,7 @@
             "resources": [
                 {
                     "type": "extensions",
-                    "apiVersion": "2018-10-01",
+                    "apiVersion": "2019-12-01",
                     "name": "[variables('DaExtensionName')]",
                     "location": "[parameters('VmssLocation')]",
                     "dependsOn": [
@@ -55,7 +55,9 @@
                         "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
                         "type": "[variables('DaExtensionType')]",
                         "typeHandlerVersion": "[variables('DaExtensionVersion')]",
-                        "autoUpgradeMinorVersion": true
+                        "autoUpgradeMinorVersion": true,
+                        "enableAutomaticUpgrade": true,
+                        "settings": {}
                     }
                 },
                 {

--- a/OnbordingTemplates/NewVmOnboarding/NewVmOnboardingParameters.json
+++ b/OnbordingTemplates/NewVmOnboarding/NewVmOnboardingParameters.json
@@ -25,7 +25,7 @@
         "virtualNetworkId": {
             "value": "/subscriptions/<SubscriptionId>/<ResourceGroup>/VmBladeTest/providers/Microsoft.Network/virtualNetworks/<VirtualNetworkName>"
         },
-        "workspaceId": {
+        "workspaceResourceId": {
             "value": "/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroup>/providers/Microsoft.OperationalInsights/workspaces/<WorkspaceName>"
         },
         "virtualMachineName": {

--- a/OnbordingTemplates/NewVmOnboarding/NewVmOnboardingTemplate.json
+++ b/OnbordingTemplates/NewVmOnboarding/NewVmOnboardingTemplate.json
@@ -118,7 +118,7 @@
         },
         {
             "type": "Microsoft.Compute/virtualMachines/extensions",
-            "apiVersion": "2017-12-01",
+            "apiVersion": "2019-12-01",
             "name": "[concat(parameters('virtualMachineName'),'/', variables('daExtensionName'))]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -128,7 +128,9 @@
                 "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
                 "type": "[variables('daExtensionType')]",
                 "typeHandlerVersion": "[variables('daExtensionVersion')]",
-                "autoUpgradeMinorVersion": true
+                "autoUpgradeMinorVersion": true,
+                "enableAutomaticUpgrade": true,
+                "settings": {}
             }
         },
         {

--- a/OnbordingTemplates/NewVmssOnboarding/NewVmssOnboardingParameters.json
+++ b/OnbordingTemplates/NewVmssOnboarding/NewVmssOnboardingParameters.json
@@ -25,6 +25,9 @@
                 "offer": "<ImageOffer>"
             }
         },
+        "osType": {
+            "Value": "<OSType>"
+        },
         "singlePlacementGroup": {
             "value": "true"
         },
@@ -64,7 +67,7 @@
         "subnetResourceGroup": {
             "value": "<VmssResourceGroup>"
         },
-        "workspaceId": {
+        "workspaceResourceId": {
             "value": "/subscriptions/<SubscriptionId>/resourceGroups/<ResourceGroup>/providers/Microsoft.OperationalInsights/workspaces/<WorkspaceName>"
         }
     }

--- a/OnbordingTemplates/NewVmssOnboarding/NewVmssOnboardingTemplate.json
+++ b/OnbordingTemplates/NewVmssOnboarding/NewVmssOnboardingTemplate.json
@@ -70,7 +70,7 @@
         "namingInfix": "[toLower(substring(concat(parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
         "networkApiVersion": "2018-01-01",
         "storageApiVersion": "2018-07-01",
-        "computeApiVersion": "2018-06-01",
+        "computeApiVersion": "2019-12-01",
         "autoscaleApiVersion": "2015-04-01",
         "vhdContainerName": "[concat(variables('namingInfix'), 'vhd')]",
         "storageAccountNamePrefix": "[toLower(concat(substring(uniqueString(resourceGroup().id), 0, 9), variables('namingInfix'), 'sa'))]",
@@ -184,7 +184,9 @@
                                     "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
                                     "type": "[variables('daExtensionType')]",
                                     "typeHandlerVersion": "[variables('daExtensionVersion')]",
-                                    "autoUpgradeMinorVersion": true
+                                    "autoUpgradeMinorVersion": true,
+                                    "enableAutomaticUpgrade": true,
+                                    "settings": {}
                                 }
                             }
                         ]


### PR DESCRIPTION
To support auto-upgrade feature, we need to add below properties to DA extension template:
1. "enableAutomaticUpgrade": true,
2.  "settings": {}
And
fixed few bugs in existing templates:
a. Correcting "WorkspaceId" to "WorkspaceResourceId" in VMSS existing and new resource creation templates.
b. Adding "OsType" as parameter in new VMSS resource creation template. 

Scenarios tested with these templates: 
1. Deployed DA extension in existing VM resource.
2. Created new VM resource.
3. Deployed DA extension in existing VMSS resource.
4. Created new VMSS resource.
